### PR TITLE
Remove reliance on stylelint isStandardSyntaxRule

### DIFF
--- a/src/rules/content-property-no-static-value/index.js
+++ b/src/rules/content-property-no-static-value/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 
 export const ruleName = 'a11y/content-property-no-static-value';
 

--- a/src/rules/font-size-is-readable/index.js
+++ b/src/rules/font-size-is-readable/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 
 export const ruleName = 'a11y/font-size-is-readable';
 

--- a/src/rules/line-height-is-vertical-rhythmed/index.js
+++ b/src/rules/line-height-is-vertical-rhythmed/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 
 export const ruleName = 'a11y/line-height-is-vertical-rhythmed';
 

--- a/src/rules/media-prefers-color-scheme/index.js
+++ b/src/rules/media-prefers-color-scheme/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 import isStandardSyntaxSelector from 'stylelint/lib/utils/isStandardSyntaxSelector';
 import isStandardSyntaxAtRule from 'stylelint/lib/utils/isStandardSyntaxAtRule';
 import isCustomSelector from 'stylelint/lib/utils/isCustomSelector';

--- a/src/rules/media-prefers-reduced-motion/index.js
+++ b/src/rules/media-prefers-reduced-motion/index.js
@@ -1,6 +1,6 @@
 import { utils } from 'stylelint';
 import { parse } from 'postcss';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 import isStandardSyntaxSelector from 'stylelint/lib/utils/isStandardSyntaxSelector';
 import isStandardSyntaxAtRule from 'stylelint/lib/utils/isStandardSyntaxAtRule';
 import isCustomSelector from 'stylelint/lib/utils/isCustomSelector';

--- a/src/rules/no-display-none/index.js
+++ b/src/rules/no-display-none/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 
 export const ruleName = 'a11y/no-display-none';
 

--- a/src/rules/no-obsolete-attribute/index.js
+++ b/src/rules/no-obsolete-attribute/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 import { obsoleteAttributes } from './obsoleteAttributes';
 
 export const ruleName = 'a11y/no-obsolete-attribute';

--- a/src/rules/no-obsolete-element/index.js
+++ b/src/rules/no-obsolete-element/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 import { obsoleteElements } from './obsoleteElements';
 
 export const ruleName = 'a11y/no-obsolete-element';

--- a/src/rules/no-outline-none/index.js
+++ b/src/rules/no-outline-none/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 
 export const ruleName = 'a11y/no-outline-none';
 

--- a/src/rules/no-spread-text/index.js
+++ b/src/rules/no-spread-text/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 
 export const ruleName = 'a11y/no-spread-text';
 

--- a/src/rules/no-text-align-justify/index.js
+++ b/src/rules/no-text-align-justify/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 
 export const ruleName = 'a11y/no-text-align-justify';
 

--- a/src/rules/selector-pseudo-class-focus/index.js
+++ b/src/rules/selector-pseudo-class-focus/index.js
@@ -1,5 +1,5 @@
 import { utils } from 'stylelint';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.cjs';
 
 const deepFlatten = (arr) => [].concat(...arr.map((v) => (Array.isArray(v) ? deepFlatten(v) : v)));
 

--- a/src/utils/isStandardSyntaxRule.cjs
+++ b/src/utils/isStandardSyntaxRule.cjs
@@ -1,0 +1,26 @@
+'use strict';
+
+const isStandardSyntaxSelector = require('stylelint/lib/utils/isStandardSyntaxSelector');
+
+/**
+ * Check whether a Node is a standard rule
+ *
+ * @param {import('postcss').Rule | import('postcss-less').Rule} rule
+ * @returns {boolean}
+ */
+module.exports = function isStandardSyntaxRule(rule) {
+  if (rule.type !== 'rule') {
+    return false;
+  }
+
+  // Ignore Less &:extend rule
+  if ('extend' in rule && rule.extend) {
+    return false;
+  }
+
+  if (!isStandardSyntaxSelector(rule.selector)) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
Stylelint 16 removed isStandardSyntaxRule.

This PR clones the utility in preparation for stylelint 16 support while staying compatible with stylelint 15 and below.